### PR TITLE
Add “create or insert” API to person

### DIFF
--- a/includes/Method/Method.php
+++ b/includes/Method/Method.php
@@ -66,23 +66,23 @@ class Method
 		return true;
 	}
 
-	protected function _prepareRequest( $api_path , $arguments ) {
+	protected function _buildUrl($api_path, $arguments) {
 		$add = '';
 
-        // allow custom variables to be passed with methods as the last argument (must be an array)
-        if ($arguments && is_array($arguments[count($arguments) - 1])) {
-        	// make sure it has string keys (allows passing non hash arguments for mapping)
-	        reset($arguments[count($arguments) - 1]);
-	        if (is_string(key($arguments[count($arguments) - 1]))) {
-		        $add = http_build_query(array_pop($arguments));
-	        }
-        }
+		// allow custom variables to be passed with methods as the last argument (must be an array)
+		if ($arguments && is_array($arguments[count($arguments) - 1])) {
+			// make sure it has string keys (allows passing non hash arguments for mapping)
+			reset($arguments[count($arguments) - 1]);
+			if (is_string(key($arguments[count($arguments) - 1]))) {
+				$add = http_build_query(array_pop($arguments));
+			}
+		}
 
-        // map arguments onto variables
-		if ( $this->_argument_mapping ) {
-			foreach ( $this->_argument_mapping as $index => $name ) {
+		// map arguments onto variables
+		if ($this->_argument_mapping) {
+			foreach ($this->_argument_mapping as $index => $name) {
 				// nothing to add?
-				if ( !isset( $arguments[ $index ] ) ) continue;
+				if (!isset( $arguments[$index])) continue;
 
 				// special procedure for arrays
 				if (is_array($arguments[$index])) {
@@ -93,15 +93,24 @@ class Method
 					continue;
 				}
 
-				$add .= ( $add ? '&' : '' ) . urlencode( $name ) . '=' . urlencode( (string)$arguments[ $index ] );
+				$add .= ($add ? '&' : '') . urlencode($name) . '=' . urlencode((string)$arguments[$index]);
 			}
 		}
 
 		// build url
-		$url = $api_path . ( $this->_uri ? '/' . $this->_uri : '' );
-		if ( $add ) $url .= '?' . $add;
+		$url = $api_path . ($this->_uri ? '/' . $this->_uri : '');
+		if ($add) {
+			$url .= '?' . $add;
+		}
 
-		return $this->_runRequest( $url , $this->_method );
+		return $url;
+	}
+
+	protected function _prepareRequest( $api_path , $arguments ) {
+		// encode arguments and build URL
+		$url = $this->_buildUrl($api_path, $arguments);
+
+		return $this->_runRequest($url, $this->_method);
 	}
 
 	public function runRequest( $api_path , $arguments ) {

--- a/includes/Model/Person/Person.php
+++ b/includes/Model/Person/Person.php
@@ -3,8 +3,183 @@
 namespace Arctic\Model\Person;
 
 use Arctic\Api;
+use Arctic\Method\Insert;
 use Arctic\Method\Method;
 use Arctic\Model;
+
+class _MethodInsertOrUpdate extends Insert
+{
+	public function __construct() {
+		parent::__construct();
+		$this->_uri = 'create-or-update';
+		$this->_argument_mapping = array('confidence');
+	}
+
+	protected function _getRequestData() {
+		/** @var Person $person */
+		$person = $this->_model;
+
+		// convert to array
+		$body = $this->_model->toArray();
+
+		// pull in references
+		if (count($person->emailaddresses)) {
+			$body['emailaddress'] = $person->emailaddresses[0]->emailaddress;
+		}
+		if (count($person->phonenumbers)) {
+			switch (strtolower($person->phonenumbers[0]->type)) {
+				case 'mobile':
+				case 'cell':
+					$key = 'phonemobile';
+					break;
+				case 'home':
+					$key = 'phonehome';
+					break;
+				case 'work':
+				case 'business':
+					$key = 'phonework';
+					break;
+				default:
+					$key = 'phonenumber';
+					break;
+			}
+			$body[$key] = $person->phonenumbers[0]->phonenumber;
+		}
+
+		return $body;
+	}
+
+	/**
+	 * Overrides the normal request format, to include email and phone fields directly in the request.
+	 * This enables better deduplication
+	 * @param $api_path
+	 * @param $arguments
+	 * @return bool
+	 */
+	protected function _prepareRequest($api_path, $arguments) {
+		if ($this->_model->doesExist()) {
+			Api::getInstance()->raiseError('Model Already Saved','Cannot be inserted again.');
+		}
+
+		// encode arguments and build URL
+		$url = $this->_buildUrl($api_path, $arguments);
+
+		// build uri
+		return $this->_runRequest($url, $this->_method, json_encode($this->_getRequestData()));
+	}
+
+	protected function _insertNewEmailAddresses(\Arctic\Reference\SetWrapper $potential_email_addresses) {
+		/** @var Person $person */
+		$person = $this->_model;
+
+		$existing = array();
+		foreach ($person->emailaddresses as $ea) {
+			$existing[] = strtolower($ea->emailaddress);
+		}
+
+		foreach ($potential_email_addresses->getRawData() as $ea) {
+			/** @var EmailAddress $ea */
+			if ($ea->doesExist()) continue;
+			if (in_array(strtolower($ea->emailaddress), $existing)) continue;
+			$ea->insert();
+		}
+	}
+
+	protected function _insertNewPhoneNumbers(\Arctic\Reference\SetWrapper $potential_phone_numbers) {
+		/** @var Person $person */
+		$person = $this->_model;
+
+		$existing = array();
+		foreach ($person->phonenumbers as $pn) {
+			$existing[] = preg_replace('/[^x0-9]+/', '', $pn->phonenumber);
+		}
+
+		foreach ($potential_phone_numbers->getRawData() as $pn) {
+			/** @var PhoneNumber $pn */
+			if ($pn->doesExist()) continue;
+			if (in_array(preg_replace('/[^x0-9]+/', '', $pn->phonenumber), $existing)) continue;
+			$pn->insert();
+		}
+	}
+
+	protected function _describeAddress(Address $addr) {
+		if (preg_match('/\d+/', sprintf('%s %s', $addr->address1, $addr->address2), $match)) {
+			$number = $match[0];
+		}
+		else {
+			$number = '';
+		}
+
+		$pc = $addr->postalcode;
+
+		return sprintf('%s:%s', $number, $pc);
+	}
+
+	protected function _insertNewAddresses(\Arctic\Reference\SetWrapper $potential_addresses) {
+		/** @var Person $person */
+		$person = $this->_model;
+
+		$existing = array();
+		foreach ($person->addresses as $addr) {
+			$existing[] = $this->_describeAddress($addr);
+		}
+
+		foreach ($potential_addresses->getRawData() as $addr) {
+			/** @var Address $addr */
+			if ($addr->doesExist()) continue;
+			if (in_array($this->_describeAddress($addr), $existing)) continue;
+			$addr->insert();
+		}
+	}
+
+	/**
+	 * Overrides some of the normal parsing response, to better determine
+	 * @param array $response
+	 * @return Model
+	 */
+	protected function _parseResponse( $response ) {
+		// get references (before filling data)
+		$references = $this->_model->getReferences();
+
+		// fill data
+		$this->_model->fillExistingData( isset( $response[ 'id' ] ) ? $response[ 'id' ] : null , $response );
+
+		// update cache if an ID was returned
+		if (isset($response['id'])) {
+			Api::getInstance()->getCacheManager()->set($response['id'], $response, $this->_model_class);
+		}
+
+		// write references BUT ONLY IF THEY DO NOT EXIST
+		foreach ($references as $name => $obj) {
+			if (isset($response[$name]) && count($response[$name])) {
+				switch ($name) {
+					case 'emailaddresses':
+						$this->_insertNewEmailAddresses($obj);
+						break;
+					case 'phonenumbers':
+						$this->_insertNewPhoneNumbers($obj);
+						break;
+					case 'addresses':
+						$this->_insertNewAddresses($obj);
+						break;
+					default:
+						// don't insert
+				}
+			}
+			else {
+				// standard approach... insert everything
+				if ($obj instanceof \Arctic\Reference\SetWrapper) {
+					$obj->insertAll();
+				}
+				else {
+					$obj->insert();
+				}
+			}
+		}
+
+		return $this->_model;
+	}
+}
 
 class _MethodMerge extends Method
 {
@@ -50,6 +225,7 @@ class _MethodMerge extends Method
  * @property Address[] $addresses
  * @property PhoneNumber[] $phonenumbers
  * @property Note[] $notes
+ * @method insertOrUpdate($confidence=0.7)
  * @method email(int $templateid=null,bool $outbox=false)
  * @method link(int $siteid=null)
  * @method merge(int|array $personid) Merge person(s) represented by $personid into the current record.
@@ -70,6 +246,11 @@ class Person extends Model
 	}
 
     protected static function _mapMethod( $method ) {
+	    // person specific method: insertOrUpdate($confidence)
+	    if ($method === 'insertOrUpdate') {
+		    return new _MethodInsertOrUpdate();
+	    }
+
         // person specific method: email($templateid=null, $outbox=false)
         if ( $method === 'email' ) {
             return new Method(Method::TYPE_EXISTING_MODEL, Api::METHOD_POST, 'email', array('templateid' , 'outbox'));
@@ -81,9 +262,9 @@ class Person extends Model
         }
 
         // person specific method: merge($personid)
-	    if ($method === 'merge') {
+        if ($method === 'merge') {
             return new _MethodMerge();
-	    }
+        }
 
         return parent::_mapMethod($method);
     }

--- a/includes/Reference/SetWrapper.php
+++ b/includes/Reference/SetWrapper.php
@@ -68,8 +68,28 @@ class SetWrapper extends ModelSet
 		}
 	}
 
+	/**
+	 * Gets the data without loading. Used by some methods to access references for uninserted objects.
+	 * @internal
+	 * @return Model[]
+	 */
+	public function getRawData() {
+		if (isset($this->_data)) {
+			return $this->_data;
+		}
+		return array();
+	}
+
 	protected function _load() {
 		if ( $sub_api_path = $this->_definition->getSubApiPath() ) {
+			// does not exist?
+			if (!$this->_parent->doesExist()) {
+				// do not actually flag as loaded, but return true and initialize
+				// important for new references
+				if (!isset($this->_data)) $this->_data = array();
+				return true;
+			}
+
 			// prefix path
             Model::forceRelativeApiPath( $this->_parent->getMyRelativeApiPath() . '/' . $sub_api_path );
 


### PR DESCRIPTION
This allows a more graceful handling of potentially duplicate customers via server side logic. Existing customers are identified based on name, email address and phone number. If a close match is found (closeness is customizable by the confidence argument), then it is updated. If a close match is not found, then a new record is created.

This requires some more complex logic to greacefully handle references. If a customer is updated, then the system removes duplicate addresses, email addresses and phone numbers before inserting other references.

This will get merged in when the server side functionality has been deployed across all installations.