### PR TITLE
Refactor reference wrappers

### DIFF
--- a/includes/Reference/Definition.php
+++ b/includes/Reference/Definition.php
@@ -65,16 +65,16 @@ class Definition
 
 	public function initiateBlankReference( $model  ) {
 		if ( $this->_type === self::TYPE_MULTIPLE ) {
-			return new SetWrapper( $model , $this->getModelClass() , $this );
+			return new SetWrapper($model, $this);
 		}
-		return new Wrapper( $model , $this->_model_class , $this );
+		return new Wrapper($model, $this);
 	}
 
 	public function initiateReferenceData( $model , $data ) {
 		if ( $this->_type === self::TYPE_MULTIPLE ) {
-			return new SetWrapper( $model , $data , $this );
+			return new SetWrapper($model,  $this, $data);
 		}
-		return new Wrapper( $model , $this->_model_class , $this );
+		return new Wrapper($model, $this, $data);
 	}
 
 	public function isReferenceSet( $value ) {

--- a/includes/Reference/SetWrapper.php
+++ b/includes/Reference/SetWrapper.php
@@ -25,7 +25,7 @@ class SetWrapper extends ModelSet
 	 */
 	protected $_definition;
 
-	public function __construct( $parent , $class_or_array , Definition $definition ) {
+	public function __construct($parent, Definition $definition, array $data=null) {
 		parent::__construct( $definition->getModelClass() , array( 'entries' => array() ) );
 
 		// potential memory leak issue
@@ -33,16 +33,12 @@ class SetWrapper extends ModelSet
 
 		// use sub api path
 		$this->_definition = $definition;
+		$this->_model_class = $this->_definition->getModelClass();
 
 		// set object
-		if ( is_array( $class_or_array ) ) {
-			$this->_model_class = $this->_definition->getModelClass();
-			$this->_setLoadedData( $class_or_array );
+		if ($data) {
+			$this->_setLoadedData($data);
 		}
-		else {
-			$this->_model_class = $class_or_array;
-		}
-
 	}
 
 	/**

--- a/includes/Reference/Wrapper.php
+++ b/includes/Reference/Wrapper.php
@@ -26,23 +26,21 @@ class Wrapper
 	 */
 	protected $_definition;
 
-	public function __construct( $parent , $class_or_instance , Definition $definition ) {
+	public function __construct($parent, Definition $definition, array $data=null) {
 		// potential memory leak issue
 		$this->_parent = $parent;
 
-		// set object
-		if ( is_object( $class_or_instance ) ) {
-			$this->_model = $class_or_instance;
-			$this->_model->setParentReference( $parent , $definition );
-			$this->_model_class = get_class( $class_or_instance );
-			$this->_loaded = true;
-		}
-		else {
-			$this->_model_class = $class_or_instance;
-		}
-
 		// use sub api path
 		$this->_definition = $definition;
+		$this->_model_class = $definition->getModelClass();
+
+		// set data
+		if ($data) {
+			$this->_model = new $this->_model_class();
+			$this->_model->fillExistingData(isset($data['id']) ? $data['id'] : null, $data);
+			$this->_model->setParentReference($parent, $definition);
+			$this->_loaded = true;
+		}
 	}
 
 	protected function _load() {


### PR DESCRIPTION
Add support for loading single reference entries that are expanded through responses (reduces the number of requests needed by the new guide schedule class that auto expands the guide entry, see #8). Uses more consistent arguments, and avoids passing redundant variables.